### PR TITLE
changed() looks at dest, not src

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -104,7 +104,7 @@ gulp.task('less', function () {
   return gulp.src(path.less)
     .pipe(cache('less'))
     .pipe(plumber())
-    .pipe(changed(path.output, {extension: '.less'}))
+    .pipe(changed(path.output, {extension: '.css'}))
     .pipe(sourcemaps.init())
     .pipe(less({
       plugins: [ cleancss ]
@@ -172,7 +172,7 @@ gulp.task('less-themes', function () {
     return gulp.src(path.themes)
       .pipe(cache('less-themes'))
       .pipe(plumber())
-      .pipe(changed(path.output, {extension: '.less'}))
+      .pipe(changed(path.output, {extension: '.css'}))
       .pipe(sourcemaps.init())
       .pipe(less({
         plugins: [ cleancss ]


### PR DESCRIPTION
So, the interesting thing is that this started from this discussion: https://github.com/lookfirst/systemjs-seed/issues/1#issuecomment-78300488

I suggest that you adopt [gulp-helpers](https://github.com/lookfirst/gulp-helpers). It was based off this gulpfile and would really help clean up a lot of your code.
