### PR TITLE
Add AMD module to the project

### DIFF
--- a/lib/countUp/countUp.js
+++ b/lib/countUp/countUp.js
@@ -1,0 +1,189 @@
+/*
+
+    countUp.js
+    by @inorganik
+
+*/
+
+// target = id of html element or var of previously selected html element where counting occurs
+// startVal = the value you want to begin at
+// endVal = the value you want to arrive at
+// decimals = number of decimal places, default 0
+// duration = duration of animation in seconds, default 2
+// options = optional object of options (see below)
+
+define([], function(){
+  return function(target, startVal, endVal, decimals, duration, options) {
+
+    // make sure requestAnimationFrame and cancelAnimationFrame are defined
+    // polyfill for browsers without native support
+    // by Opera engineer Erik Möller
+    var lastTime = 0;
+    var vendors = ['webkit', 'moz', 'ms', 'o'];
+    for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+        window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
+        window.cancelAnimationFrame =
+          window[vendors[x]+'CancelAnimationFrame'] || window[vendors[x]+'CancelRequestAnimationFrame'];
+    }
+    if (!window.requestAnimationFrame) {
+        window.requestAnimationFrame = function(callback, element) {
+            var currTime = new Date().getTime();
+            var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+            var id = window.setTimeout(function() { callback(currTime + timeToCall); },
+              timeToCall);
+            lastTime = currTime + timeToCall;
+            return id;
+        }
+    }
+    if (!window.cancelAnimationFrame) {
+        window.cancelAnimationFrame = function(id) {
+            clearTimeout(id);
+        }
+    }
+
+     // default options
+    this.options = options || {
+        useEasing : true, // toggle easing
+        useGrouping : true, // 1,000,000 vs 1000000
+        separator : ',', // character to use as a separator
+        decimal : '.' // character to use as a decimal
+    };
+    if (this.options.separator == '') this.options.useGrouping = false;
+    if (this.options.prefix == null) this.options.prefix = '';
+    if (this.options.suffix == null) this.options.suffix = '';
+
+    var self = this;
+
+    this.d = (typeof target === 'string') ? document.getElementById(target) : target;
+    this.startVal = Number(startVal);
+    this.endVal = Number(endVal);
+    this.countDown = (this.startVal > this.endVal) ? true : false;
+    this.startTime = null;
+    this.timestamp = null;
+    this.remaining = null;
+    this.frameVal = this.startVal;
+    this.rAF = null;
+    this.decimals = Math.max(0, decimals || 0);
+    this.dec = Math.pow(10, this.decimals);
+    this.duration = duration * 1000 || 2000;
+
+    this.version = function () { return '1.3.2' };
+
+    // Print value to target
+    this.printValue = function(value) {
+        var result = (!isNaN(value)) ? self.formatNumber(value) : '--';
+        if (self.d.tagName == 'INPUT') {
+            this.d.value = result;
+        }
+        else if (self.d.tagName == 'text') {
+            this.d.textContent = result;
+        }
+        else {
+            this.d.innerHTML = result;
+        }
+    };
+
+    // Robert Penner's easeOutExpo
+    this.easeOutExpo = function(t, b, c, d) {
+        return c * (-Math.pow(2, -10 * t / d) + 1) * 1024 / 1023 + b;
+    };
+    this.count = function(timestamp) {
+
+        if (self.startTime === null) self.startTime = timestamp;
+
+        self.timestamp = timestamp;
+
+        var progress = timestamp - self.startTime;
+        self.remaining = self.duration - progress;
+
+        // to ease or not to ease
+        if (self.options.useEasing) {
+            if (self.countDown) {
+                var i = self.easeOutExpo(progress, 0, self.startVal - self.endVal, self.duration);
+                self.frameVal = self.startVal - i;
+            } else {
+                self.frameVal = self.easeOutExpo(progress, self.startVal, self.endVal - self.startVal, self.duration);
+            }
+        } else {
+            if (self.countDown) {
+                var i = (self.startVal - self.endVal) * (progress / self.duration);
+                self.frameVal = self.startVal - i;
+            } else {
+                self.frameVal = self.startVal + (self.endVal - self.startVal) * (progress / self.duration);
+            }
+        }
+
+        // don't go past endVal since progress can exceed duration in the last frame
+        if (self.countDown) {
+            self.frameVal = (self.frameVal < self.endVal) ? self.endVal : self.frameVal;
+        } else {
+            self.frameVal = (self.frameVal > self.endVal) ? self.endVal : self.frameVal;
+        }
+
+        // decimal
+        self.frameVal = Math.round(self.frameVal*self.dec)/self.dec;
+
+        // format and print value
+        self.printValue(self.frameVal);
+
+        // whether to continue
+        if (progress < self.duration) {
+            self.rAF = requestAnimationFrame(self.count);
+        } else {
+            if (self.callback != null) self.callback();
+        }
+    };
+    this.start = function(callback) {
+        self.callback = callback;
+        // make sure values are valid
+        if (!isNaN(self.endVal) && !isNaN(self.startVal)) {
+            self.rAF = requestAnimationFrame(self.count);
+        } else {
+            console.log('countUp error: startVal or endVal is not a number');
+            self.printValue();
+        }
+        return false;
+    };
+    this.stop = function() {
+        cancelAnimationFrame(self.rAF);
+    };
+    this.reset = function() {
+        self.startTime = null;
+        self.startVal = startVal;
+        cancelAnimationFrame(self.rAF);
+        self.printValue(self.startVal);
+    };
+    this.resume = function() {
+        self.stop();
+        self.startTime = null;
+        self.duration = self.remaining;
+        self.startVal = self.frameVal;
+        requestAnimationFrame(self.count);
+    };
+    this.formatNumber = function(nStr) {
+        nStr = nStr.toFixed(self.decimals);
+        nStr += '';
+        var x, x1, x2, rgx;
+        x = nStr.split('.');
+        x1 = x[0];
+        x2 = x.length > 1 ? self.options.decimal + x[1] : '';
+        rgx = /(\d+)(\d{3})/;
+        if (self.options.useGrouping) {
+            while (rgx.test(x1)) {
+                x1 = x1.replace(rgx, '$1' + self.options.separator + '$2');
+            }
+        }
+        return self.options.prefix + x1 + x2 + self.options.suffix;
+    };
+
+    // format startVal on initialization
+    self.printValue(self.startVal);
+}
+
+});
+
+// Example:
+// var numAnim = new countUp("SomeElementYouWantToAnimate", 0, 99.99, 2, 2.5);
+// numAnim.start();
+// with optional callback:
+// numAnim.start(someMethodToCallOnComplete);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "object.assign": "^1.1.1",
     "rsvp": "^3.0.16",
     "run-sequence": "^1.0.2",
-    "systemjs-route-bundler": "^1.2.0",
+    "systemjs-route-bundler": "^1.2.1",
     "vinyl-paths": "^1.0.0",
     "node-v8-clone": "^0.6.2",
     "gulp-cached": "^1.0.2"

--- a/src/app/forms/forms.js
+++ b/src/app/forms/forms.js
@@ -1,6 +1,7 @@
 import angular from 'angular';
 import ModalModule from 'common/components/modal';
 import formsTemplate from './forms.tpl';
+import countUp from 'countUp';
 
 export default angular
   .module('forms', ['app/forms/forms.tpl.html', 'common.components.modal'])

--- a/system.config.js
+++ b/system.config.js
@@ -1,5 +1,6 @@
 System.config({
   "baseURL": "",
+  "defaultJSExtensions": true,
   "transpiler": "babel",
   "babelOptions": {
     "optional": [
@@ -13,7 +14,6 @@ System.config({
     "github:*": "jspm_packages/github/*",
     "npm:*": "jspm_packages/npm/*"
   },
-  "defaultJSExtensions": true,
   "buildCSS": true,
   "separateCSS": false
 });
@@ -157,9 +157,6 @@ System.config({
       "path": "github:jspm/nodelibs-path@0.1.0",
       "process": "github:jspm/nodelibs-process@0.1.1"
     },
-    "npm:core-js@0.8.4": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
-    },
     "npm:core-js@0.9.18": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
       "process": "github:jspm/nodelibs-process@0.1.1",
@@ -193,10 +190,8 @@ System.config({
       "inherits": "npm:inherits@2.0.1",
       "isarray": "npm:isarray@0.0.1",
       "process": "github:jspm/nodelibs-process@0.1.1",
-      "stream": "github:jspm/nodelibs-stream@0.1.0",
       "stream-browserify": "npm:stream-browserify@1.0.0",
-      "string_decoder": "npm:string_decoder@0.10.31",
-      "util": "github:jspm/nodelibs-util@0.1.0"
+      "string_decoder": "npm:string_decoder@0.10.31"
     },
     "npm:source-map@0.1.43": {
       "amdefine": "npm:amdefine@0.1.0",

--- a/system.config.js
+++ b/system.config.js
@@ -11,6 +11,7 @@ System.config({
     "*.json": "dist/*.json",
     "*.css": "dist/*.css",
     "systemjs-test/*": "src/*.js",
+    "lib/*": "lib/*.js",
     "github:*": "jspm_packages/github/*.js",
     "npm:*": "jspm_packages/npm/*.js"
   },
@@ -51,6 +52,10 @@ System.config({
       "deps": [
         "npm:ui-router-extras@0.0.13/release/modular/ct-ui-router-extras.core"
       ]
+    },
+    "lib/countUp/countUp": {
+      "format": "amd",
+      "exports": "countUp"
     }
   }
 });
@@ -63,6 +68,7 @@ System.config({
     "babel": "npm:babel-core@5.6.15",
     "babel-runtime": "npm:babel-runtime@5.6.15",
     "core-js": "npm:core-js@0.9.18",
+    "countUp": "lib/countUp/countUp",
     "css": "github:systemjs/plugin-css@0.1.10",
     "json": "github:systemjs/plugin-json@0.1.0",
     "ocLazyLoad": "github:ocombe/ocLazyLoad@0.5.2/dist/ocLazyLoad",

--- a/system.config.js
+++ b/system.config.js
@@ -7,13 +7,11 @@ System.config({
     ]
   },
   "paths": {
-    "*": "dist/*.js",
-    "*.json": "dist/*.json",
-    "*.css": "dist/*.css",
-    "systemjs-test/*": "src/*.js",
-    "lib/*": "lib/*.js",
-    "github:*": "jspm_packages/github/*.js",
-    "npm:*": "jspm_packages/npm/*.js"
+    "*": "dist/*",
+    "systemjs-test/*": "src/*",
+    "lib/*": "lib/*",
+    "github:*": "jspm_packages/github/*",
+    "npm:*": "jspm_packages/npm/*"
   },
   "defaultJSExtensions": true,
   "buildCSS": true,


### PR DESCRIPTION
Bundling AMD modules into the project doesn't work after upgrading to systemjs 0.18.4 and systemjs-builder 0.12.2. 

This is a use case to demonstrate it.

To test:
- checkout the amd_modules branch of the repo
- `npm install`
- `gulp release`

You should see the following error when you open the application

```
Uncaught (in promise) Error: AMD module http://127.0.0.1:8080/lib/countUp/countUp.js did not define
    Error loading http://127.0.0.1:8080/lib/countUp/countUp.js from http://127.0.0.1:8080/dist/app/forms/forms.js
    Error loading http://127.0.0.1:8080/lib/countUp/countUp.js
    at l.<anonymous> (http://127.0.0.1:8080/dist/app/app.js:12:30787)
    at l.n [as instantiate] (http://127.0.0.1:8080/dist/app/app.js:13:4104)
    at http://127.0.0.1:8080/dist/app/app.js:12:3573
```

Note that everything works fine if I don't bundle and only compile the applicaiton.

Edit: the bundler code is here: https://github.com/Swimlane/systemjs-route-bundler
