### PR TITLE
Put the output of replace task in dist/index.html to avoid committing changes to original

### DIFF
--- a/build/tasks/replace.js
+++ b/build/tasks/replace.js
@@ -24,5 +24,5 @@ gulp.task('replace', function(){
         }
       ]
     }))
-    .pipe(gulp.dest('./'));
+    .pipe(gulp.dest('./dist'));
 });


### PR DESCRIPTION
It produced several commits because I rebased from upstream after committing the change - oh well?
