### PR TITLE
chore(npm.scripts) add simpler step to start the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,8 @@ This seed project demonstrates the [systemjs-route-bundler](https://github.com/S
 
 ### Install & Run
 
-1. `npm install -g gulp jspm`
-2. `npm install`
-3. `gulp watch serve`
-4. Browse to `http://localhost:9000`
+1. `npm start`
+2. Browse to `http://localhost:9000`
 
 ### Gulp Tasks
 

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     }
   },
   "scripts": {
-    "postinstall": "jspm install"
+    "postinstall": "jspm install",
+    "prestart": "npm install",
+    "start": "gulp watch serve"
   }
 }


### PR DESCRIPTION
We don't need to use some global install from NPM
