### PR TITLE
adding jshint to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "gulp-uglify": "^1.5.3",
     "isparta": "^4.0.0",
     "jasmine-core": "^2.4.1",
+    "jshint": "^2.9.2",
     "jshint-stylish": "^2.1.0",
     "jspm": "^0.16.34",
     "karma": "^0.13.22",


### PR DESCRIPTION
as brought up in issue #64 - after `npm install`, `npm run start` breaks until jshint is installed
